### PR TITLE
adapt parameters order calling kane.kanes_equations

### DIFF
--- a/_doc/notebooks/2016/pydata/js_pydy_mass_spring_damper.ipynb
+++ b/_doc/notebooks/2016/pydata/js_pydy_mass_spring_damper.ipynb
@@ -375,7 +375,7 @@
               "$$(- c v + g m - k x)\\mathbf{\\hat{c}_x}$$"
             ],
             "text/plain": [
-              "(-c\u22c5v + g\u22c5m - k\u22c5x) c_x"
+              "(-c⋅v + g⋅m - k⋅x) c_x"
             ]
           },
           "execution_count": 11,
@@ -409,7 +409,7 @@
               "$$- c v + g m - k x - m \\dot{v}$$"
             ],
             "text/plain": [
-              "-c\u22c5v + g\u22c5m - k\u22c5x - m\u22c5v\u0307"
+              "-c⋅v + g⋅m - k⋅x - m⋅v̇"
             ]
           },
           "execution_count": 12,
@@ -440,9 +440,9 @@
               "$$\\left ( \\frac{1}{m} \\left(- c v + g m - k x\\right), \\quad v\\right )$$"
             ],
             "text/plain": [
-              "\u239b-c\u22c5v + g\u22c5m - k\u22c5x   \u239e\n",
-              "\u239c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500, v\u239f\n",
-              "\u239d       m           \u23a0"
+              "⎛-c⋅v + g⋅m - k⋅x   ⎞\n",
+              "⎜────────────────, v⎟\n",
+              "⎝       m           ⎠"
             ]
           },
           "execution_count": 13,
@@ -506,7 +506,7 @@
               "$$\\left ( \\left[\\begin{matrix}- c v + g m - k x\\end{matrix}\\right], \\quad \\left[\\begin{matrix}- m \\dot{v}\\end{matrix}\\right]\\right )$$"
             ],
             "text/plain": [
-              "([-c\u22c5v + g\u22c5m - k\u22c5x], [-m\u22c5v\u0307])"
+              "([-c⋅v + g⋅m - k⋅x], [-m⋅v̇])"
             ]
           },
           "execution_count": 16,
@@ -515,7 +515,7 @@
         }
       ],
       "source": [
-        "fr, frstar = kane.kanes_equations([(P, forces)], [mass])\n",
+        "fr, frstar = kane.kanes_equations([mass], [(P, forces)])\n",
         "fr, frstar"
       ]
     },
@@ -537,9 +537,9 @@
               "$$\\left ( \\left[\\begin{matrix}1 & 0\\\\0 & m\\end{matrix}\\right], \\quad \\left[\\begin{matrix}v\\\\- c v + g m - k x\\end{matrix}\\right]\\right )$$"
             ],
             "text/plain": [
-              "\u239b\u23a11  0\u23a4, \u23a1       v        \u23a4\u239e\n",
-              "\u239c\u23a2    \u23a5  \u23a2                \u23a5\u239f\n",
-              "\u239d\u23a30  m\u23a6  \u23a3-c\u22c5v + g\u22c5m - k\u22c5x\u23a6\u23a0"
+              "⎛⎡1  0⎤, ⎡       v        ⎤⎞\n",
+              "⎜⎢    ⎥  ⎢                ⎥⎟\n",
+              "⎝⎣0  m⎦  ⎣-c⋅v + g⋅m - k⋅x⎦⎠"
             ]
           },
           "execution_count": 17,
@@ -571,11 +571,11 @@
               "$$\\left[\\begin{matrix}v\\\\\\frac{1}{m} \\left(- c v + g m - k x\\right)\\end{matrix}\\right]$$"
             ],
             "text/plain": [
-              "\u23a1       v        \u23a4\n",
-              "\u23a2                \u23a5\n",
-              "\u23a2-c\u22c5v + g\u22c5m - k\u22c5x\u23a5\n",
-              "\u23a2\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u23a5\n",
-              "\u23a3       m        \u23a6"
+              "⎡       v        ⎤\n",
+              "⎢                ⎥\n",
+              "⎢-c⋅v + g⋅m - k⋅x⎥\n",
+              "⎢────────────────⎥\n",
+              "⎣       m        ⎦"
             ]
           },
           "execution_count": 18,
@@ -834,7 +834,7 @@
               ]
             },
             "text/html": [
-              "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>3.5.0 64bit [MSC v.1900 64 bit (AMD64)]</td></tr><tr><td>IPython</td><td>4.2.0</td></tr><tr><td>OS</td><td>Windows 10.0.10586</td></tr><tr><td>pydy</td><td>0.3.1</td></tr><tr><td>numpy</td><td>1.11.1rc1</td></tr><tr><td>scipy</td><td>0.17.1</td></tr><tr><td colspan='2'>Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?\u00e9t\u00e9)</td></tr></table>"
+              "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>3.5.0 64bit [MSC v.1900 64 bit (AMD64)]</td></tr><tr><td>IPython</td><td>4.2.0</td></tr><tr><td>OS</td><td>Windows 10.0.10586</td></tr><tr><td>pydy</td><td>0.3.1</td></tr><tr><td>numpy</td><td>1.11.1rc1</td></tr><tr><td>scipy</td><td>0.17.1</td></tr><tr><td colspan='2'>Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?été)</td></tr></table>"
             ],
             "text/latex": [
               "\\begin{tabular}{|l|l|}\\hline\n",
@@ -845,7 +845,7 @@
               "pydy & 0.3.1 \\\\ \\hline\n",
               "numpy & 1.11.1rc1 \\\\ \\hline\n",
               "scipy & 0.17.1 \\\\ \\hline\n",
-              "\\hline \\multicolumn{2}{|l|}{Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?\u00e9t\u00e9)} \\\\ \\hline\n",
+              "\\hline \\multicolumn{2}{|l|}{Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?été)} \\\\ \\hline\n",
               "\\end{tabular}\n"
             ],
             "text/plain": [
@@ -856,7 +856,7 @@
               "pydy 0.3.1\n",
               "numpy 1.11.1rc1\n",
               "scipy 0.17.1\n",
-              "Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?\u00e9t\u00e9)"
+              "Tue Jun 14 17:29:07 2016 Paris, Madrid (heure d?été)"
             ]
           },
           "execution_count": 32,
@@ -894,7 +894,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.0"
+      "version": "3.11.6"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Looks like parameters order in `kane.kanes_equations/sympy.physics.mechanics` changed since 2016.

![image](https://github.com/sdpython/jupytalk/assets/1609739/7f267859-4ef2-4c10-8370-b2ccaa114410)
